### PR TITLE
Use media query to avoid issue with sticky button on touch devices

### DIFF
--- a/style.css
+++ b/style.css
@@ -77,6 +77,14 @@ a:active {
   margin-top: 1rem;
 }
 
+@media (hover: hover) {
+  .answerButton:hover {
+    color: black;
+    border: 2px solid black;
+    cursor: pointer;
+  }
+}
+
 .answer_wrong {
   color: var(--color-incorrect);
   border-color: var(--color-incorrect);
@@ -124,6 +132,7 @@ section {
 .cta:hover {
   color: var(--color-links);
   border-color: var(--color-links);
+  cursor: pointer;
 }
 
 .resultTable {


### PR DESCRIPTION
In the first iteration, I noticed the "sticky hover" problem on my phone, which caused a problem because when you saw a new question, one of the answer choices was already "highlighted" (depending on what button you pressed for the previous question).

So I looked into it and found [this solution on CSS-Tricks using a media query](https://css-tricks.com/solving-sticky-hover-states-with-media-hover-hover/).

I saw you removed the hover state in the newest iteration, but I think it's still nice to have that UI feedback on desktop. So for this PR, I used the approach for the `.answerButton:hover` class. I also added the pointer cursor so it works nicely on desktop. And I added the pointer to the cta button for consistency.